### PR TITLE
FLUID-6200 - Uncomment Firefox headless config

### DIFF
--- a/src/js/testem-component.js
+++ b/src/js/testem-component.js
@@ -433,10 +433,9 @@ fluid.defaults("gpii.testem.base", {
         ]
     },
     "headlessBrowserArgs": {
-        // TODO: enable once a new enough version of Firefox is available in CI.
-        // "Firefox": [
-        //     "--headless"
-        // ],
+        "Firefox": [
+            "--headless"
+        ],
         // See this ticket for details on the minimum options required to get "headless" Chrome working: https://github.com/testem/testem/issues/1106#issuecomment-298841383
         "Chrome": [
             "--disable-gpu",


### PR DESCRIPTION
This seems to be working great for running Infusion tests!

Tested on Fedora 28 with Chrome 67 and Firefox 60 (outside and inside Docker container).