### PR TITLE
GPII-3467: Allow coverage sender to be used without QUnit or Testem.

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -39,3 +39,19 @@ Please note, as shown in the above example:
 
 The middleware that receives the coverage data is built into Testem component grades found in this package.  See
 [the Testem component docs](./testem-component.md) for more details.
+
+## Coverage Sender Advanced Options
+
+The middleware that serves up the coverage sender accepts three options, which are used to generate the client-side code
+that your browser loads.
+
+| Option           | Type        | Description                           |
+| ---------------- | ----------- | ------------------------------------- |
+| `exposeCallback` | `{Boolean}` | Whether to expose the callback that sends coverage data as the global named variable `window.gpii.testem.coverage.afterTestsCallback` so that it can be called directly in situations where Testem and QUnit are not available. |
+| `hookTestem`     | `{Boolean}` | Whether to hook the callback that sends coverage data into the Testem lifecycle, so that test results are send when Testem detects that the tests on a page have completed.  Defaults to `true`. |
+| `hookQunit`      | `{Boolean}` | Whether to hook the callback that sends coverage data into the QUnit lifecycle, so that test results are send when QUnit detects that the tests on a page have completed. Defaults to `false`. |
+
+The `hookTestem` option is enabled by default, and if you are only using Testem, you should not need to supply custom
+options. See [the rollup tests in this package](../tests/js/rollup-non-testem-tests.js) for an example of using QUnit
+without using Testem.  See [the callback tests in this package](../tests/js/callback-tests.js) for an example of using
+the coverage sender without either Testem or QUnit.

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -48,8 +48,8 @@ that your browser loads.
 | Option           | Type        | Description                           |
 | ---------------- | ----------- | ------------------------------------- |
 | `exposeCallback` | `{Boolean}` | Whether to expose the callback that sends coverage data as the global named variable `window.gpii.testem.coverage.afterTestsCallback` so that it can be called directly in situations where Testem and QUnit are not available. |
-| `hookTestem`     | `{Boolean}` | Whether to hook the callback that sends coverage data into the Testem lifecycle, so that test results are send when Testem detects that the tests on a page have completed.  Defaults to `true`. |
-| `hookQunit`      | `{Boolean}` | Whether to hook the callback that sends coverage data into the QUnit lifecycle, so that test results are send when QUnit detects that the tests on a page have completed. Defaults to `false`. |
+| `hookTestem`     | `{Boolean}` | Whether to hook the callback that sends coverage data into the Testem lifecycle, so that test results are sent when Testem detects that the tests on a page have completed.  Defaults to `true`. |
+| `hookQunit`      | `{Boolean}` | Whether to hook the callback that sends coverage data into the QUnit lifecycle, so that test results are sent when QUnit detects that the tests on a page have completed. Defaults to `false`. |
 
 The `hookTestem` option is enabled by default, and if you are only using Testem, you should not need to supply custom
 options. See [the rollup tests in this package](../tests/js/rollup-non-testem-tests.js) for an example of using QUnit

--- a/src/js/client/coverageSender.js
+++ b/src/js/client/coverageSender.js
@@ -5,7 +5,7 @@
 
     <script src="/coverage/client/coverageSender.js"></script>
 
-    NOTE: This script requires Testem, and must be loaded after Testem loads, but before your tests start.
+    NOTE: By default, this script requires Testem, and must be loaded after Testem loads, but before your tests start.
 
     Adapted from https://github.com/testem/testem/blob/master/examples/coverage_istanbul/tests.html#L11
 

--- a/src/js/client/coverageSender.js
+++ b/src/js/client/coverageSender.js
@@ -70,6 +70,11 @@
             }
         };
 
+
+        if (fluid.get(options, "exposeCallback")) {
+            window.gpii.testem.coverage.afterTestsCallback = afterTestsCallback;
+        }
+
         var hookTestem = fluid.get(options, "hookTestem");
         if (hookTestem && Testem) {
             Testem.afterTests(afterTestsCallback);
@@ -80,4 +85,4 @@
             QUnit.done(afterTestsCallback);
         }
     };
-})(typeof Testem !== "undefined" ? Testem : false, QUnit);
+})(typeof Testem !== "undefined" ? Testem : false, typeof QUnit !== "undefined" ? QUnit : false);

--- a/src/js/client/coverageSender.js
+++ b/src/js/client/coverageSender.js
@@ -14,7 +14,6 @@
     care of that yourself.
 
  */
-/* globals Testem, QUnit */
 (function (Testem, QUnit) {
     "use strict";
     // Pure JS equivalent of a fluid.registerNamespace call.
@@ -85,4 +84,4 @@
             QUnit.done(afterTestsCallback);
         }
     };
-})(typeof Testem !== "undefined" ? Testem : false, typeof QUnit !== "undefined" ? QUnit : false);
+})(window.Testem, window.QUnit);

--- a/src/js/coverageClientMiddleware.js
+++ b/src/js/coverageClientMiddleware.js
@@ -36,6 +36,7 @@ fluid.defaults("gpii.testem.middleware.coverageClient", {
     coveragePort: 7000,
     hookTestem: true,
     hookQUnit: false,
+    exposeCallback: false,
     invokers: {
         middleware: {
             funcName: "gpii.testem.middleware.coverageClient.middlewareImpl",

--- a/src/js/coverageClientMiddleware.js
+++ b/src/js/coverageClientMiddleware.js
@@ -6,7 +6,6 @@ var gpii  = fluid.registerNamespace("gpii");
 var fs = require("fs");
 
 require("gpii-express");
-//fluid.require("%gpii-express");
 
 fluid.registerNamespace("gpii.testem.middleware.coverageClient");
 gpii.testem.middleware.coverageClient.middlewareImpl = function (that, req, res, next) {

--- a/src/templates/coverage-client-invoker.handlebars
+++ b/src/templates/coverage-client-invoker.handlebars
@@ -1,4 +1,4 @@
 (function (){
     "use strict";
-    window.gpii.testem.coverage.sender({ coveragePort: %coveragePort, hookTestem: %hookTestem, hookQUnit: %hookQUnit });
+    window.gpii.testem.coverage.sender({ coveragePort: %coveragePort, hookTestem: %hookTestem, hookQUnit: %hookQUnit, exposeCallback: %exposeCallback });
 })();

--- a/tests/callback-fixtures/index.html
+++ b/tests/callback-fixtures/index.html
@@ -1,0 +1,21 @@
+<html>
+<head>
+    <title>Testing manual exercising of client-side fixtures.</title>
+
+    <script type="text/javascript" src="/node_modules/infusion/dist/infusion-all.js"></script>
+
+    <!-- Wire up a coverage reporter to save test coverage reports after the run completes -->
+    <script type="text/javascript" src="/coverage/client/coverageSender.js"></script>
+
+    <!-- The client-side code under test -->
+    <script type="text/javascript" src="/src/js/lucky-coin.js"></script>
+</head>
+<body>
+    <p>These tests have no visible output.</p>
+
+    <script type="text/javascript">
+        var coin = my.lucky.coin();
+        coin.flip();
+    </script>
+</body>
+</html>

--- a/tests/callback-fixtures/src/js/lucky-coin.js
+++ b/tests/callback-fixtures/src/js/lucky-coin.js
@@ -1,0 +1,27 @@
+(function (fluid) {
+    "use strict";
+    var my = fluid.registerNamespace("my");
+    fluid.registerNamespace("my.lucky.coin");
+    my.lucky.coin.announceResults = function (isHeads) {
+        fluid.log(isHeads ? "HEADS!" : "TAILS.");
+    };
+
+    my.lucky.coin.isHeads = function () {
+        return true;
+    };
+
+    my.lucky.coin.flip = function () {
+        var isHeads = my.lucky.coin.isHeads();
+        my.lucky.coin.announceResults(isHeads);
+    };
+
+    fluid.defaults("my.lucky.coin", {
+        gradeNames: ["fluid.component"],
+        invokers: {
+            "flip": {
+                funcName: "my.lucky.coin.flip",
+                args: []
+            }
+        }
+    });
+})(fluid);

--- a/tests/js/callback-tests.js
+++ b/tests/js/callback-tests.js
@@ -1,0 +1,194 @@
+/* eslint-env node */
+"use strict";
+var fluid = require("infusion");
+var gpii  = fluid.registerNamespace("gpii");
+
+var jqUnit = require("node-jqunit");
+
+var os   = require("os");
+var fs   = require("fs");
+var path = require("path");
+
+require("../../");
+
+require("kettle");
+require("gpii-webdriver");
+gpii.webdriver.loadTestingSupport();
+
+fluid.registerNamespace("gpii.tests.testem.callback");
+
+// Simple function to retrieve data our "test result collector" set aside on the client side.
+gpii.tests.testem.callback.fireCallback = function () {
+    window.gpii.testem.coverage.afterTestsCallback();
+};
+
+gpii.tests.testem.callback.checkTestResults = function (that) {
+    var coverageFiles = fs.readdirSync(that.options.coverageDir);
+    jqUnit.assertTrue("There should be coverage data.", coverageFiles && coverageFiles.length > 0);
+    fluid.each(coverageFiles, function (filename) {
+        var fullPath = path.resolve(that.options.coverageDir, filename);
+        var stats = fs.statSync(fullPath);
+        jqUnit.assertTrue("Coverage files should not be empty.", stats.size > 0);
+        try {
+            require(fullPath);
+            jqUnit.assert("Coverage files should be valid JSON.");
+        }
+        catch (error) {
+            jqUnit.fail(error);
+        }
+    });
+
+};
+
+gpii.tests.testem.callback.cleanup = function (that) {
+    var promises = [];
+
+    fluid.each(["coverageDir", "instrumentedSourceDir"], function (dirToClean) {
+        var pathToClean = fluid.get(that, ["options", dirToClean]);
+        promises.push(gpii.testem.cleanupDir({ path: pathToClean }, {}));
+    });
+
+    var sequence = fluid.promise.sequence(promises);
+    sequence.then(
+        function () { fluid.log("Finished cleanup."); },
+        fluid.fail
+    );
+};
+
+fluid.defaults("gpii.tests.testem.callback.caseHolder", {
+    gradeNames: ["gpii.test.webdriver.caseHolder"],
+    rawModules: [{
+        name: "Testing direct use of coverage client callback...",
+        tests: [
+            {
+                name: "Attempt to collect coverage data by directly calling the coverage client callback...",
+                type: "test",
+                sequence: [
+                    {
+                        func: "{testEnvironment}.webdriver.get",
+                        args: ["{testEnvironment}.options.url"]
+                    },
+                    // Give the tests time to run.
+                    {
+                        event:    "{testEnvironment}.webdriver.events.onGetComplete",
+                        listener: "{testEnvironment}.webdriver.sleep",
+                        args:     [250]
+                    },
+                    {
+                        event:    "{testEnvironment}.webdriver.events.onSleepComplete",
+                        listener: "{testEnvironment}.webdriver.executeScript",
+                        args:     [gpii.tests.testem.callback.fireCallback]
+                    },
+                    // Give the data time to be transmitted.
+                    {
+                        func: "{testEnvironment}.webdriver.sleep",
+                        args: [250]
+                    },
+                    {
+                        event:    "{testEnvironment}.webdriver.events.onSleepComplete",
+                        listener: "gpii.tests.testem.callback.checkTestResults",
+                        args:     ["{testEnvironment}"]
+                    }
+                ]
+            }
+        ]
+    }]
+});
+
+gpii.tests.testem.callback.generateUniqueTmpDir = function (that, prefix) {
+    return path.resolve(os.tmpdir(), prefix + "-" + that.id);
+};
+
+gpii.tests.testem.callback.instrumentSource = function (that) {
+    gpii.testem.instrumenter.instrument("%gpii-testem/tests/callback-fixtures/src", that.options.instrumentedSourceDir).then(function () {
+        that.events.onSourceInstrumented.fire();
+    }, fluid.fail);
+};
+
+fluid.defaults("gpii.tests.testem.callback.environment", {
+    gradeNames: ["gpii.test.webdriver.testEnvironment.withExpress"],
+    coveragePrefix: "coverage",
+    coverageDir: "@expand:gpii.tests.testem.callback.generateUniqueTmpDir({that}, {that}.options.coveragePrefix)",
+    instrumentedPrefix: "instrumented",
+    instrumentedSourceDir: "@expand:gpii.tests.testem.callback.generateUniqueTmpDir({that}, {that}.options.instrumentedPrefix)",
+    url: {
+        expander: {
+            funcName: "fluid.stringTemplate",
+            args:     ["http://localhost:%port/tests/callback-fixtures/index.html", { port: "{that}.options.port"}]
+        }
+    },
+    listeners: {
+        "onCreate.instrumentSource": {
+            funcName: "gpii.tests.testem.callback.instrumentSource",
+            args:     ["{that}"]
+        },
+        "onDestroy.cleanup": {
+            funcName: "gpii.tests.testem.callback.cleanup",
+            args: ["{that}"]
+        }
+    },
+    events: {
+        onSourceInstrumented: null,
+        onFixturesConstructed: {
+            events: {
+                onDriverReady:  "onDriverReady",
+                onExpressReady: "onExpressReady",
+                onSourceInstrumented: "onSourceInstrumented"
+            }
+        }
+    },
+    components: {
+        caseHolder: {
+            type: "gpii.tests.testem.callback.caseHolder"
+        },
+        express: {
+            options: {
+                components: {
+                    coverage: {
+                        type: "gpii.testem.coverage.router",
+                        options: {
+                            coveragePort: "{testEnvironment}.options.port",
+                            components: {
+                                client: {
+                                    options: {
+                                        hookTestem:     false,
+                                        hookQUnit:      false,
+                                        exposeCallback: true
+                                    }
+                                },
+                                coverageReceiver: {
+                                    options: {
+                                        coverageDir: "{gpii.tests.testem.callback.environment}.options.coverageDir"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    nm: {
+                        type: "gpii.express.router.static",
+                        options: {
+                            path:    "/node_modules",
+                            content: ["%gpii-testem/node_modules"]
+                        }
+                    },
+                    tests: {
+                        type: "gpii.express.router.static",
+                        options: {
+                            path:    "/tests",
+                            content: ["%gpii-testem/tests"]
+                        }
+                    },
+                    src: {
+                        type: "gpii.express.router.static",
+                        options: {
+                            path:    "/src",
+                            content: ["{gpii.tests.testem.callback.environment}.options.instrumentedSourceDir"]
+                        }
+                    }
+                }
+            }
+        }
+    }
+});
+
+gpii.test.webdriver.allBrowsers({ baseTestEnvironment: "gpii.tests.testem.callback.environment" });


### PR DESCRIPTION
See [GPII-3467](https://issues.gpii.net/browse/GPII-3467) for details.