### PR TITLE
NOJIRA: Improve uniqueness of file naming for client coverage reports

### DIFF
--- a/src/js/coverageReceiverMiddleware.js
+++ b/src/js/coverageReceiverMiddleware.js
@@ -46,8 +46,9 @@ gpii.testem.coverage.receiver.middlewareImpl = function (that, request, response
 
     var testPath     = fluid.get(coveragePayload.document, "URL");
     var testFilename = testPath ? testPath.split("/").pop() : "unknown";
+    var timestamp    = Date.now();
 
-    var coverageFilename    = ["coverage", "-", browser.name, "-", browser.version, "-", testFilename, "-", that.id, "-", Math.round(Math.random() * 10000), ".json"].join("");
+    var coverageFilename    = ["coverage", browser.name, browser.version, testFilename, that.id, timestamp].join("-") + ".json";
     var coverageOutputPath  = path.join(resolvedCoverageDir, coverageFilename);
 
     fs.writeFile(coverageOutputPath, JSON.stringify(coveragePayload.coverage, null, 2), { encoding: "utf8"}, function (error) {


### PR DESCRIPTION
It's a pretty rare case but we've experienced some inconsistencies in `gpii-app` renderer processes coverage which makes use of the `gpii.testem.coverage.express` (coverageServer.js).
 
These are some changes of a collision of random numbers which are currently used for uniqueness of filenames. We could use a timestamp instead which should better ensure uniqueness.
