### PR TITLE
GPII-3706: Make `nyc` a full dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,24 +25,24 @@
     "homepage": "https://github.com/GPII/gpii-testem/",
     "dependencies": {
         "glob": "7.1.3",
-        "gpii-express": "1.0.14",
-        "infusion": "3.0.0-dev.20180312T184056Z.e4d2974d2",
+        "gpii-express": "1.0.15",
+        "infusion": "3.0.0-dev.20180801T212157Z.09bf3d438",
         "istanbul": "0.4.5",
-        "istanbul-lib-instrument": "2.3.2",
+        "istanbul-lib-instrument": "3.1.0",
         "mkdirp": "0.5.1",
         "node-jqunit": "1.1.8",
-        "nyc": "13.1.0",
-        "rimraf": "2.6.2",
-        "testem": "2.10.0"
+        "nyc": "13.2.0",
+        "rimraf": "2.6.3",
+        "testem": "2.12.0"
     },
     "devDependencies": {
-        "eslint": "5.4.0",
+        "eslint": "5.13.0",
         "eslint-config-fluid": "1.3.0",
-        "form-data": "2.3.2",
-        "gpii-grunt-lint-all": "1.0.4",
+        "form-data": "2.3.3",
+        "gpii-grunt-lint-all": "1.0.5",
         "gpii-webdriver": "1.0.2",
         "grunt": "1.0.3",
-        "kettle": "1.8.0",
+        "kettle": "1.10.1",
         "qunitjs": "2.4.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dependencies": {
         "glob": "7.1.3",
         "gpii-express": "1.0.15",
-        "infusion": "3.0.0-dev.20180801T212157Z.09bf3d438",
+        "infusion": "3.0.0-dev.20190212T124747Z.23b4bc89d",
         "istanbul": "0.4.5",
         "istanbul-lib-instrument": "3.1.0",
         "mkdirp": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "istanbul-lib-instrument": "2.3.2",
         "mkdirp": "0.5.1",
         "node-jqunit": "1.1.8",
+        "nyc": "13.1.0",
         "rimraf": "2.6.2",
         "testem": "2.10.0"
     },
@@ -42,7 +43,6 @@
         "gpii-webdriver": "1.0.2",
         "grunt": "1.0.3",
         "kettle": "1.8.0",
-        "nyc": "13.1.0",
         "qunitjs": "2.4.1"
     }
 }


### PR DESCRIPTION
See [GPII-3706](https://issues.gpii.net/browse/GPII-3706) for details.