### PR TITLE
GPII-3803: Remove outdated istanbul dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,10 @@
         "glob": "7.1.3",
         "gpii-express": "1.0.15",
         "infusion": "3.0.0-dev.20190212T124747Z.23b4bc89d",
-        "istanbul": "0.4.5",
         "istanbul-lib-instrument": "3.1.0",
         "mkdirp": "0.5.1",
         "node-jqunit": "1.1.8",
-        "nyc": "13.2.0",
+        "nyc": "13.3.0",
         "rimraf": "2.6.3",
         "testem": "2.12.0"
     },


### PR DESCRIPTION
See [GPII-3803](https://issues.gpii.net/browse/GPII-3803) for details.