### PR TITLE
GH-30: Change coverage server port to avoid conflict in OS X Monterey (resolves #30).

### DIFF
--- a/docs/testem-component.md
+++ b/docs/testem-component.md
@@ -18,7 +18,7 @@ see below.
 | `cwd`                     | `{String}`  | Defaults to `process.cwd()`, i.e. the directory from which the script was called. |
 | `testemDir`               | `{String}`  | The directory in which testem's browser settings and temporary files should be stored. |
 | `wrappedEventTimeout`     | `{Number}`  | How long to wait (in milliseconds) before triggering a timeout when waiting for key startup/shutdown events. |
-| `coveragePort` (required) | `{Number}`  | The port fluid-express should listen on to record coverage data. Defaults to `7000`.|
+| `coveragePort` (required) | `{Number}`  | The port fluid-express should listen on to record coverage data. Defaults to `7003`.|
 | `coverageUrl`             | `{String}`  | The URL on which the coverage listener should be run.  Set based on `coveragePort` by default. |
 | `coverageDir` (required)  | `{String}`  | The full or package-relative path where coverage data should be saved. By default, a unique subdirectory is created in `os.tmpdir()`. |
 | `reportsDir` (required)   | `{String}`  | The full or package-relative path where coverage reports and test results should be saved. By default, a unique subdirectory is created in `os.tmpdir()`. |

--- a/src/js/coverageClientMiddleware.js
+++ b/src/js/coverageClientMiddleware.js
@@ -32,7 +32,7 @@ fluid.defaults("fluid.testem.middleware.coverageClient", {
     path:    "/client",
     baseClientSource: "%fluid-testem/src/js/client/coverageSender.js",
     clientInvokerTemplatePath: "%fluid-testem/src/templates/coverage-client-invoker.handlebars" ,
-    coveragePort: 7000,
+    coveragePort: 7003,
     hookTestem: true,
     hookQUnit: false,
     exposeCallback: false,

--- a/src/js/testem-component.js
+++ b/src/js/testem-component.js
@@ -361,7 +361,7 @@ fluid.testem.constructProxies = function (sourceDirs, contentDirs, additionalPro
 
 fluid.defaults("fluid.testem.base", {
     gradeNames:  ["fluid.component"],
-    coveragePort: 7000,
+    coveragePort: 7003,
     coverageUrl: {
         expander: {
             funcName: "fluid.stringTemplate",


### PR DESCRIPTION
See #30 for details.